### PR TITLE
Streaming file processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,7 @@ name = "certificate_carver"
 version = "0.1.3"
 dependencies = [
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "copy_in_place 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -128,6 +129,11 @@ dependencies = [
 [[package]]
 name = "cfg-if"
 version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "copy_in_place"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1256,6 +1262,7 @@ dependencies = [
 "checksum bzip2-sys 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2c5162604199bbb17690ede847eaa6120a3f33d5ab4dcc8e7c25b16d849ae79b"
 "checksum cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
+"checksum copy_in_place 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b792a46b1ef44bb5e9a04721d34e186522431be965a283437107843d62ddbaad"
 "checksum core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25bfd746d203017f7d5cbd31ee5d8e17f94b6521c7af77ece6c9e4b2d4b16c67"
 "checksum core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "065a5d7ffdcbc8fa145d6f0746f3555025b9097a9e9cda59f7467abae670c78d"
 "checksum crc 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd5d02c0aac6bd68393ed69e00bbc2457f3e89075c6349db7189618dc4ddc1d7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 base64 = "0.9"
+copy_in_place = "0.2.0"
 encoding = "0.2"
 hex = "0.3"
 lazy_static = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,7 +365,7 @@ impl Carver {
                                 if let Ok(bytes) = pem_base64_decode(&encoded) {
                                     results.push(CertificateBytes(bytes));
                                 }
-                                b64_start + m2.end()
+                                m.end() - 5
                             }
                             None => {
                                 // The footer isn't in the buffer yet, try reading more if the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 extern crate base64;
+extern crate copy_in_place;
 extern crate encoding;
 extern crate hex;
 extern crate regex;
@@ -19,6 +20,7 @@ extern crate serde_derive;
 pub mod ldapprep;
 pub mod x509;
 
+use copy_in_place::copy_in_place;
 use regex::bytes::Regex;
 use reqwest::Url;
 use sha2::{Digest, Sha256};
@@ -240,6 +242,53 @@ impl TrustRoots {
     }
 }
 
+struct BufReaderOverlap<R> {
+    inner: R,
+    buf: Box<[u8]>,
+    pos: usize,
+    cap: usize,
+}
+
+impl<R: Read> BufReaderOverlap<R> {
+    fn with_capacity(cap: usize, inner: R) -> BufReaderOverlap<R> {
+        BufReaderOverlap {
+            inner,
+            buf: vec![0; cap].into_boxed_slice(),
+            pos: 0,
+            cap: 0,
+        }
+    }
+
+    fn fill_buf(&mut self, min_size: usize) -> std::io::Result<(&[u8], bool)> {
+        // like BufRead::fill_buf, but reads if there is min_size or less left in the buffer,
+        // not just when it is empty. Returns a buffer and a boolean to indicate end of file,
+        // or an error.
+        let remaining = self.cap - self.pos;
+        let mut eof = false;
+        if remaining <= min_size {
+            if self.pos > 0 {
+                copy_in_place(&mut self.buf, self.pos..self.cap, 0);
+                self.cap = remaining;
+                self.pos = 0;
+            }
+            while self.cap < self.buf.len() && self.cap <= min_size {
+                let n = self.inner.read(&mut self.buf[self.cap..])?;
+                self.cap += n;
+                if n == 0 {
+                    eof = true;
+                    break;
+                }
+            }
+        }
+        Ok((&self.buf[self.pos..self.cap], eof))
+    }
+
+    fn consume(&mut self, amt: usize) {
+        debug_assert!(self.pos + amt <= self.cap);
+        self.pos = std::cmp::min(self.pos + amt, self.cap);
+    }
+}
+
 pub struct Carver {
     pub log_urls: Vec<String>,
     pub map: HashMap<CertificateFingerprint, CertificateRecord>,
@@ -272,34 +321,82 @@ impl Carver {
 
         let mut results = Vec::new();
 
-        // TODO: stream through a buffer and keep searching that
-        let mut data = Vec::new();
-        match stream.read_to_end(&mut data) {
-            Ok(_) => (),
-            Err(_) => return results,
-        }
-        for caps in HEADER_RE.captures_iter(&data) {
-            if let Some(m) = caps.name("DER") {
-                let length_bytes = &caps["length"];
-                let length = ((length_bytes[0] as usize) << 8) | length_bytes[1] as usize;
-                let start = m.start();
-                let end = start + length + 4;
-                if end <= data.len() {
-                    results.push(CertificateBytes(data[start..end].to_vec()));
-                }
-            }
-            if let Some(m) = caps.name("PEM") {
-                let start = m.start() + 27;
-                if let Some(m2) = PEM_END_RE.find(&data[start..]) {
-                    let end = start + m2.start();
-                    let encoded = &data[start..end];
-                    if let Ok(bytes) = pem_base64_decode(&encoded) {
-                        results.push(CertificateBytes(bytes));
+        const MAX_CERTIFICATE_SIZE: usize = 16 * 1024;
+        const BUFFER_SIZE: usize = 32 * 1024;
+        const OVERLAP: usize = 27; // enough to capture the PEM header (and the DER prefix)
+        let mut stream = BufReaderOverlap::with_capacity(BUFFER_SIZE, stream);
+        let mut min_size = OVERLAP;
+        loop {
+            let (buf, eof) = match stream.fill_buf(min_size) {
+                Ok((buf, eof)) => (buf, eof),
+                Err(_) => return results,
+            };
+            min_size = OVERLAP;
+            let consume_amount: usize = match HEADER_RE.captures(&buf) {
+                Some(caps) => {
+                    if let Some(m) = caps.name("DER") {
+                        let length_bytes = &caps["length"];
+                        let length = ((length_bytes[0] as usize) << 8) | length_bytes[1] as usize;
+                        let start = m.start();
+                        let end = start + length + 4;
+                        if end <= buf.len() {
+                            results.push(CertificateBytes(buf[start..end].to_vec()));
+                            end
+                        } else {
+                            // The end of this certificate isn't in the buffer yet, try reading
+                            // more if the buffer is too small
+                            if buf.len() - start < MAX_CERTIFICATE_SIZE && !eof {
+                                min_size = MAX_CERTIFICATE_SIZE;
+                                start
+                            } else {
+                                // The DER sequence is too long, this was probably a false
+                                // positive. Discard the first byte of the match, and keep
+                                // searching from there.
+                                1
+                            }
+                        }
+                    } else if let Some(m) = caps.name("PEM") {
+                        let header_start = m.start();
+                        let b64_start = header_start + 27;
+                        match PEM_END_RE.find(&buf[b64_start..]) {
+                            Some(m2) => {
+                                let b64_end = b64_start + m2.start();
+                                let encoded = &buf[b64_start..b64_end];
+                                if let Ok(bytes) = pem_base64_decode(&encoded) {
+                                    results.push(CertificateBytes(bytes));
+                                }
+                                b64_start + m2.end()
+                            }
+                            None => {
+                                // The footer isn't in the buffer yet, try reading more if the
+                                // buffer is too small
+                                if buf.len() - header_start < MAX_CERTIFICATE_SIZE && !eof {
+                                    min_size = MAX_CERTIFICATE_SIZE;
+                                    header_start
+                                } else {
+                                    // Couldn't find a footer, this was probably a false positive.
+                                    // Keep searching from after the header.
+                                    m.end() - 5
+                                }
+                            }
+                        }
+                    } else {
+                        panic!("Impossible else branch, if this regex matches, one of its two capturing groups must match");
                     }
                 }
-            }
+                None => {
+                    if eof {
+                        return results;
+                    }
+                    if buf.len() > OVERLAP {
+                        buf.len() - OVERLAP
+                    } else {
+                        0
+                    }
+                }
+            };
+            stream.consume(consume_amount);
         }
-        results
     }
 
     pub fn carve_file<RS: Read + Seek>(&self, mut file: &mut RS) -> Vec<CertificateBytes> {

--- a/tests/test_carve.rs
+++ b/tests/test_carve.rs
@@ -30,3 +30,18 @@ fn test_load_der_cert() {
     let certs = carver.carve_file(&mut stream);
     assert_eq!(certs.len(), 1);
 }
+
+#[test]
+fn test_overlapping_pem_header() {
+    let mut bytes = Vec::new();
+    //bytes.extend_from_slice(b"-----BEGIN CERTIFICATE");
+    bytes.extend_from_slice(b"-----BEGIN CERTIFICATE");
+    bytes.extend_from_slice(include_bytes!("files/bespoke/rootca.crt"));
+    let mut stream = Cursor::new(bytes);
+    let carver = Carver::new(Vec::new());
+    let certs = carver.carve_file(&mut stream);
+    assert_eq!(certs.len(), 1);
+    let cert = &certs[0];
+    let fp = cert.fingerprint();
+    assert_eq!(&fp.0, b"\x34\x47\x5A\x72\x1C\xF4\x8D\x2F\x90\x79\x31\x6E\x7E\x32\xC4\xBE\x83\x35\x8D\xD7\xD4\x42\xD9\x31\x12\x6D\x02\x16\x26\xC7\x12\x3D");
+}

--- a/tests/test_carve.rs
+++ b/tests/test_carve.rs
@@ -10,7 +10,7 @@ fn test_load_pem_chain() {
     let mut stream = Cursor::new(&bytes[..]);
     let carver = Carver::new(Vec::new());
     let certs = carver.carve_file(&mut stream);
-    assert!(certs.len() == 2);
+    assert_eq!(certs.len(), 2);
 }
 
 #[test]
@@ -19,7 +19,7 @@ fn test_load_zip_chain() {
     let mut stream = Cursor::new(&bytes[..]);
     let carver = Carver::new(Vec::new());
     let certs = carver.carve_file(&mut stream);
-    assert!(certs.len() == 2);
+    assert_eq!(certs.len(), 2);
 }
 
 #[test]
@@ -28,5 +28,5 @@ fn test_load_der_cert() {
     let mut stream = Cursor::new(&bytes[..]);
     let carver = Carver::new(Vec::new());
     let certs = carver.carve_file(&mut stream);
-    assert!(certs.len() == 1);
+    assert_eq!(certs.len(), 1);
 }

--- a/tests/test_cross_sign.rs
+++ b/tests/test_cross_sign.rs
@@ -44,7 +44,7 @@ fn test_cross_signatures() {
     carver.scan_file_object(&mut cert2, "cert2");
     carver.scan_file_object(&mut cert3, "cert3");
     carver.scan_file_object(&mut cert4, "cert4");
-    assert!(carver.map.len() == 5);
+    assert_eq!(carver.map.len(), 5);
     let issuer_lookup = carver.build_issuer_lookup();
 
     let mut log = LogInfo::new("http://127.0.0.0/");
@@ -52,5 +52,5 @@ fn test_cross_signatures() {
         .add_roots(&[CertificateBytes(decode_pem(root_pem))]);
 
     let chains = carver.build_chains(&cert4_fp, &issuer_lookup, &log.trust_roots);
-    assert!(chains.len() == 2);
+    assert_eq!(chains.len(), 2);
 }

--- a/tests/test_format_names.rs
+++ b/tests/test_format_names.rs
@@ -16,7 +16,7 @@ fn test_format_names_helper(pem: &[u8], expected: &str) {
     let mut string = String::new();
     cur.read_to_string(&mut string).unwrap();
     println!("{}", string);
-    assert!(string == expected);
+    assert_eq!(string, expected);
 }
 
 #[test]

--- a/tests/test_offset.rs
+++ b/tests/test_offset.rs
@@ -45,3 +45,59 @@ fn test_offset_der_cert() {
         assert_eq!(certs.len(), 1, "padding is {}", padding);
     }
 }
+
+#[test]
+fn test_pem_then_der() {
+    let pem_bytes = include_bytes!("files/davidsherenowitsa.party/fullchain.pem");
+    let der_bytes = include_bytes!("files/davidsherenowitsa.party/cert.der");
+    let mut vec1 = vec![0; MAX_PADDING];
+    vec1.extend_from_slice(pem_bytes);
+    let vec1 = vec1;
+    let zeros = &vec1[..MAX_PADDING];
+    let carver = Carver::new(Vec::new());
+    for padding_infix in PADDINGS.iter() {
+        let mut vec2 = vec1.clone();
+        vec2.extend_from_slice(&zeros[..*padding_infix]);
+        vec2.extend_from_slice(der_bytes);
+        for padding_prefix in PADDINGS.iter() {
+            let offset: usize = MAX_PADDING - *padding_prefix;
+            let mut stream = Cursor::new(&vec2[offset..]);
+            let certs = carver.carve_file(&mut stream);
+            assert_eq!(
+                certs.len(),
+                3,
+                "prefix padding is {}, infix padding is {}",
+                padding_prefix,
+                padding_infix
+            );
+        }
+    }
+}
+
+#[test]
+fn test_der_then_pem() {
+    let der_bytes = include_bytes!("files/davidsherenowitsa.party/cert.der");
+    let pem_bytes = include_bytes!("files/davidsherenowitsa.party/fullchain.pem");
+    let mut vec1 = vec![0; MAX_PADDING];
+    vec1.extend_from_slice(der_bytes);
+    let vec1 = vec1;
+    let zeros = &vec1[..MAX_PADDING];
+    let carver = Carver::new(Vec::new());
+    for padding_infix in PADDINGS.iter() {
+        let mut vec2 = vec1.clone();
+        vec2.extend_from_slice(&zeros[..*padding_infix]);
+        vec2.extend_from_slice(pem_bytes);
+        for padding_prefix in PADDINGS.iter() {
+            let offset: usize = MAX_PADDING - *padding_prefix;
+            let mut stream = Cursor::new(&vec2[offset..]);
+            let certs = carver.carve_file(&mut stream);
+            assert_eq!(
+                certs.len(),
+                3,
+                "prefix padding is {}, infix padding is {}",
+                padding_prefix,
+                padding_infix
+            );
+        }
+    }
+}

--- a/tests/test_offset.rs
+++ b/tests/test_offset.rs
@@ -1,0 +1,47 @@
+extern crate certificate_carver;
+
+use std::io::Cursor;
+
+use certificate_carver::Carver;
+
+const MAX_PADDING: usize = 10 * 1024 * 1024;
+const PADDINGS: [usize; 8] = [
+    0,
+    1,
+    512,
+    1024,
+    1024 * 1024,
+    5 * 1024 * 1024,
+    10 * 1024 * 1024 - 1,
+    10 * 1024 * 1024,
+];
+
+#[test]
+fn test_offset_pem_cert() {
+    let bytes = include_bytes!("files/davidsherenowitsa.party/fullchain.pem");
+    let mut padded = vec![0; MAX_PADDING];
+    padded.extend_from_slice(bytes);
+    let padded = padded;
+    let carver = Carver::new(Vec::new());
+    for padding in PADDINGS.iter() {
+        let offset: usize = MAX_PADDING - *padding;
+        let mut stream = Cursor::new(&padded[offset..]);
+        let certs = carver.carve_file(&mut stream);
+        assert!(certs.len() == 2);
+    }
+}
+
+#[test]
+fn test_offset_der_cert() {
+    let bytes = include_bytes!("files/davidsherenowitsa.party/cert.der");
+    let mut padded = vec![0; MAX_PADDING];
+    padded.extend_from_slice(bytes);
+    let padded = padded;
+    let carver = Carver::new(Vec::new());
+    for padding in PADDINGS.iter() {
+        let offset: usize = MAX_PADDING - *padding;
+        let mut stream = Cursor::new(&padded[offset..]);
+        let certs = carver.carve_file(&mut stream);
+        assert!(certs.len() == 1);
+    }
+}

--- a/tests/test_offset.rs
+++ b/tests/test_offset.rs
@@ -27,7 +27,7 @@ fn test_offset_pem_cert() {
         let offset: usize = MAX_PADDING - *padding;
         let mut stream = Cursor::new(&padded[offset..]);
         let certs = carver.carve_file(&mut stream);
-        assert_eq!(certs.len(), 2);
+        assert_eq!(certs.len(), 2, "padding is {}", padding);
     }
 }
 
@@ -42,6 +42,6 @@ fn test_offset_der_cert() {
         let offset: usize = MAX_PADDING - *padding;
         let mut stream = Cursor::new(&padded[offset..]);
         let certs = carver.carve_file(&mut stream);
-        assert!(certs.len() == 1);
+        assert_eq!(certs.len(), 1, "padding is {}", padding);
     }
 }

--- a/tests/test_offset.rs
+++ b/tests/test_offset.rs
@@ -27,7 +27,7 @@ fn test_offset_pem_cert() {
         let offset: usize = MAX_PADDING - *padding;
         let mut stream = Cursor::new(&padded[offset..]);
         let certs = carver.carve_file(&mut stream);
-        assert!(certs.len() == 2);
+        assert_eq!(certs.len(), 2);
     }
 }
 

--- a/tests/test_pem_too_short.rs
+++ b/tests/test_pem_too_short.rs
@@ -1,0 +1,15 @@
+extern crate certificate_carver;
+
+use std::io::Cursor;
+
+use certificate_carver::Carver;
+
+const BYTES: &[u8] = b"-----BEGIN CERTIFICATE-----\nMIIC";
+
+#[test]
+fn test_pem_too_short() {
+    let mut stream = Cursor::new(&BYTES);
+    let carver = Carver::new(Vec::new());
+    let certs = carver.carve_stream(&mut stream);
+    assert!(certs.is_empty());
+}


### PR DESCRIPTION
This PR overhauls the core carving function. Instead of reading an entire file into a `Vec` and running the regular expression over everything in memory, it now reads into, and scans over, a fixed-size buffer. This will make the program easier to use, as it won't hit out-of-memory errors when given multi-gigabyte files. The PR also includes a few more carving tests, as there are now more edge cases to consider.